### PR TITLE
Fix method names in report when receiver is not a pointer

### DIFF
--- a/run/deps.go
+++ b/run/deps.go
@@ -435,11 +435,16 @@ func methID(thing, fn any, args ...any) string {
 		// we want to remove the "main.(*CI)" part to replace it with sid
 		fid = fid[idx+2:]
 	} else {
-		idx = strings.LastIndex(fid, sid[:(len(sid)-2)])
+		sidSlice := sid
+		sIdx := strings.Index(sid, "{")
+		if sIdx >= 0 {
+			sidSlice = sid[:sIdx]
+		}
+		idx = strings.LastIndex(fid, sidSlice)
 		if idx >= 0 {
 			// if the function receiver is not a pointer, fid will look like "main.Lint.glciFix()"
 			// we want to remove the "main.Lint" part to replace it with sid
-			fid = fid[(idx + len(sid) - 1):]
+			fid = fid[(idx + len(sidSlice) + 1):]
 		}
 	}
 	return fmt.Sprintf("%s.%s", sid, fid)

--- a/run/deps.go
+++ b/run/deps.go
@@ -429,7 +429,19 @@ type selfIdentifier interface {
 func methID(thing, fn any, args ...any) string {
 	sid := structID(thing)
 	fid := funcID(fn, args...)
-	fid = fid[strings.LastIndex(fid, ").")+2:]
+	idx := strings.LastIndex(fid, ").")
+	if idx >= 0 {
+		// if the function receiver is a pointer, fid will look like "main.(*CI).PreCommit([]string{})"
+		// we want to remove the "main.(*CI)" part to replace it with sid
+		fid = fid[idx+2:]
+	} else {
+		idx = strings.LastIndex(fid, sid[:(len(sid)-2)])
+		if idx >= 0 {
+			// if the function receiver is not a pointer, fid will look like "main.Lint.glciFix()"
+			// we want to remove the "main.Lint" part to replace it with sid
+			fid = fid[(idx + len(sid) - 1):]
+		}
+	}
 	return fmt.Sprintf("%s.%s", sid, fid)
 }
 

--- a/run/deps_test.go
+++ b/run/deps_test.go
@@ -272,4 +272,6 @@ func Test_methID(t *testing.T) {
 	test := &MyThing{field: "xxx"}
 	s := methID(test, test.private)
 	assert.Equal(t, "pkg.package-operator.run/cardboard/run.MyThing{field:xxx}.private()", s)
+	s = methID(test, test.privateReceiverNotPointer)
+	assert.Equal(t, "pkg.package-operator.run/cardboard/run.MyThing{field:xxx}.privateReceiverNotPointer()", s)
 }

--- a/run/manager_test.go
+++ b/run/manager_test.go
@@ -70,6 +70,9 @@ func (m *MyThing) privateMustPanic(_ string) {
 	Must(fmt.Errorf("explosion"))
 }
 
+func (m MyThing) privateReceiverNotPointer(_ string) {
+}
+
 func TestManager_Call_unknownTarget(t *testing.T) {
 	log := slogt.New(t)
 	mgr := New(WithLogger{log})


### PR DESCRIPTION
When generating a report, if the function receiver is not a pointer, the displayed name is broken. This PR fixes this bug.

### How to reproduce

Just run `./do ci:precommit` from the root of this repo.

### Actual names (examples)

* `main.Lint{}.ain.Lint.glciFix()`
* `main.Lint{}.ain.Lint.goModTidyAll()`
* `main.Lint{}.ain.Lint.goModTidy("./modules/kubeclients/")`

### Desired names

* `main.Lint{}.glciFix()`
* `main.Lint{}.goModTidyAll()`
* `main.Lint{}.goModTidy("./modules/kubeclients/")`