### PR TITLE
decorate registration errors with the calling functions source file n…

### DIFF
--- a/run/decorate.go
+++ b/run/decorate.go
@@ -1,0 +1,20 @@
+package run
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func decorateWithCallingSourceLine(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// make sure to change this number if calls get introduced to the stack or make it parametrizable by the caller
+	// TODO: unit test that serves as a regression test for the correct "depth"
+	_, fi, line, ok := runtime.Caller(2)
+	if !ok {
+		return fmt.Errorf("[source code not found] %w", err)
+	}
+	return fmt.Errorf("[%s#L%d] %w", fi, line, err)
+}

--- a/run/manager.go
+++ b/run/manager.go
@@ -127,7 +127,9 @@ func (m *Manager) ParallelDeps(ctx context.Context, parent DependencyIDer, deps 
 }
 
 func (m *Manager) Register(things ...any) error {
-	return m.registerAll(things...)
+	return decorateWithCallingSourceLine(
+		m.registerAll(things...),
+	)
 }
 
 func (m *Manager) Call(ctx context.Context, id string, args []string) (err error) {
@@ -159,7 +161,7 @@ func (m *Manager) RegisterGoTool(tool, packageURL, version string) error {
 
 func (m *Manager) RegisterAndRun(ctx context.Context, things ...any) error {
 	if err := m.registerAll(things...); err != nil {
-		return err
+		return decorateWithCallingSourceLine(err)
 	}
 	if err := m.Run(ctx); err != nil {
 		return err
@@ -170,7 +172,7 @@ func (m *Manager) RegisterAndRun(ctx context.Context, things ...any) error {
 
 func (m *Manager) MustRegisterAndRun(ctx context.Context, things ...any) {
 	if err := m.registerAll(things...); err != nil {
-		m.logger.Error(err.Error())
+		m.logger.Error((decorateWithCallingSourceLine(err)).Error())
 		os.Exit(1)
 	}
 	if err := m.Run(ctx); err != nil {


### PR DESCRIPTION
…ame and line number to help users investigate where an offendind registration call happens


This turns
![image](https://github.com/package-operator/cardboard/assets/5539202/90203d09-f666-400f-afcd-28eac5383f02)
into
![image](https://github.com/package-operator/cardboard/assets/5539202/68f3d9bd-4141-4ebb-b046-2aaa5ac2bfba)
