### PR TITLE
sh.Runner: decorate error with offending script when execution of shr.Bash fails

### DIFF
--- a/sh/sh.go
+++ b/sh/sh.go
@@ -49,7 +49,15 @@ func (r *Runner) Run(cmd string, args ...string) error {
 
 func (r *Runner) Bash(script ...string) error {
 	scriptBuf := bytes.NewBufferString(strings.Join(script, "\n"))
-	return r.run(outOrStdoutIfNil(r.stdout), outOrStderrIfNil(r.stderr), scriptBuf, "bash")
+	if err := r.run(
+		outOrStdoutIfNil(r.stdout),
+		outOrStderrIfNil(r.stderr),
+		scriptBuf,
+		"bash",
+	); err != nil {
+		return fmt.Errorf("failed to run bash script: %w\nscript: %s", err, strings.Join(script, "\n"))
+	}
+	return nil
 }
 
 func (r *Runner) Output(cmd string, args ...string) (string, error) {


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>


![image](https://github.com/package-operator/cardboard/assets/5539202/9f550fc5-aa91-4d30-a9ea-ad2d5be8290f)

vs

![image](https://github.com/package-operator/cardboard/assets/5539202/3ebf264f-7ba0-48e9-839f-09eef56e9235)
