### PR TITLE
Add link to issue which explains, at least partially, why /dev/dm-0 is passed through to the kind node containers

### DIFF
--- a/modules/kind/kindcluster.go
+++ b/modules/kind/kindcluster.go
@@ -240,6 +240,7 @@ func sanitizeClusterConfig(conf *kindv1alpha4.Cluster) {
 
 func defaultClusterConfig(conf *kindv1alpha4.Cluster) {
 	kindv1alpha4.SetDefaultsCluster(conf)
+	// https://github.com/kubernetes-sigs/kind/issues/2411
 	if _, err := os.Lstat("/dev/dm-0"); err == nil {
 		for i := range conf.Nodes {
 			conf.Nodes[i].ExtraMounts = []kindv1alpha4.Mount{


### PR DESCRIPTION
Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
