### PR TITLE
Implement toggle to prefix task stdout/stderr streams with datetime and task

### DIFF
--- a/sh/sh.go
+++ b/sh/sh.go
@@ -52,12 +52,7 @@ type taskWriter struct {
 
 // taskWriter prefixes each line of the output with a timestamp and the task name.
 func (t taskWriter) Write(p []byte) (n int, err error) {
-	msgLines := bytes.Split(p, []byte{'\n'})
-
-	// if original message ends with a newline, remove the last empty line
-	if len(msgLines) > 0 && len(msgLines[len(msgLines)-1]) == 0 {
-		msgLines = msgLines[:len(msgLines)-1]
-	}
+	msgLines := bytes.Split(bytes.TrimRight(p, "\n"), []byte{'\n'})
 
 	dateTime := time.Now().UTC().Format("2006-01-02 15:04:05.000")
 	prefix := fmt.Sprintf("%s [%s %s] ", dateTime, t.taskName, t.streamName)

--- a/sh/sh.go
+++ b/sh/sh.go
@@ -50,7 +50,7 @@ type taskWriter struct {
 	streamName string
 }
 
-// prefixWriter prefixes each line of the output with a timestamp and the task name.
+// taskWriter prefixes each line of the output with a timestamp and the task name.
 func (t taskWriter) Write(p []byte) (n int, err error) {
 	msgLines := strings.Split(string(p), "\n")
 
@@ -60,12 +60,15 @@ func (t taskWriter) Write(p []byte) (n int, err error) {
 	}
 
 	dateTime := time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	var prefixedMsg bytes.Buffer
 	for _, line := range msgLines {
 		prefixedLine := fmt.Sprintf("%s [%s %s] %s\n", dateTime, t.taskName, t.streamName, line)
-		_, err := t.w.Write([]byte(prefixedLine))
-		if err != nil {
-			return len(p), err
-		}
+		prefixedMsg.WriteString(prefixedLine)
+	}
+
+	_, err = t.w.Write(prefixedMsg.Bytes())
+	if err != nil {
+		return 0, err
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
This pr implements a toggleable feature that prefixes log lines with the current datetime and the task they originated from.
It is enabled by default and can be disabled with `CARDBOARD_NO_LOG_PREFIX` envvar.

output with prefix:
`2024-10-15 10:29:45.441 [podman OUT] Successfully tagged localhost:5001/package-operator/package-operator-manager:v1.12.0-20-g20c7f5a`

There are 3 methods that can be used to run tasks:
- sh.Run - prefix is added based on the command name 
  - vast majority of tasks are executed though this method
- sh.Output - prefix is not added, so we can still get raw task output
  - [only used to determine version now](https://github.com/package-operator/package-operator/blob/9067fd0de5ebc36b32c2547995aeea383fb1b4cc/cmd/build/image.go#L103)
- sh.Bash - prefix is not added, because there is not a way to determine task name
  - datetime prefix could be added 
  - from my brief look it is only used for tests and prefixing them with datetime doesn't seem very useful


downside:
tasks can't rectroactively change terminal output when log prefixing is enabled
this means slightly uglier output in terminal
for example podman won't be able to show progress
`Copying blob ad94df8bebe6 [==============>-----------------------] 16.3MiB / 41.6MiB | 1.0 GiB/s`
and then replace it when it' finished:
`Copying blob ad94df8bebe6 done |`

Jira issue: [PKO-148](https://issues.redhat.com/browse/PKO-148)