### PR TITLE
log waiter error

### DIFF
--- a/kubeutils/wait/wait.go
+++ b/kubeutils/wait/wait.go
@@ -156,7 +156,7 @@ func (w *Waiter) WaitForObject(
 		func(ctx context.Context) (done bool, err error) {
 			err = w.client.Get(ctx, client.ObjectKeyFromObject(object), object)
 			if err != nil {
-				//nolint:nilerr // retry on transient errors
+				log.Info("waiting for object errored", "key", key, "err", err)
 				return false, nil
 			}
 


### PR DESCRIPTION
log waiter error to make debugging easier (it took me an embarrassingly long time to figure out that there was a typo in the name of the object i was waiting for and I only figured it out after adding this log call)

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
