### PR TITLE
Update golangci-lint version

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	err := errors.Join(
 		mgr.RegisterGoTool("gotestfmt", "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt", "2.5.0"),
-		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/cmd/golangci-lint", "1.58.1"),
+		mgr.RegisterGoTool("golangci-lint", "github.com/golangci/golangci-lint/cmd/golangci-lint", "1.60.1"),
 		mgr.Register(&Dev{}, &CI{}),
 	)
 	if err != nil {


### PR DESCRIPTION
## What
Update `golangci-lint` dependency to version `1.60.1`.

## Why
The pipeline on @radimous's #412 is failing on the `lint-and-unit` job. The problem seems to be that the current version of
`golangci-lint:v1.58.1` is incompatible with `go:v1.23`. Therefore, I upgraded the version to the one used in PKO: `golangci-lint:v1.60.1`.