### PR TITLE
build(dependabot): group updates of k8s.io/* dependencies into a single PR per go module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: gomod
   directory: /kubeutils
   schedule:
@@ -18,6 +23,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: gomod
   directory: /modules/kind
   schedule:
@@ -27,6 +37,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: gomod
   directory: /modules/kubeclients
   schedule:
@@ -36,6 +51,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: gomod
   directory: /modules/oci
   schedule:
@@ -45,6 +65,11 @@ updates:
     dependency-name: "*"
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  groups:
+    kube:
+      applies-to: version-updates
+      patterns:
+      - k8s.io/*
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
https://issues.redhat.com/browse/PKO-200

copyingover changes from package-operator repo:
https://github.com/package-operator/package-operator/pull/1637
https://github.com/package-operator/package-operator/pull/1642

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>