### PR TITLE
Add build(deps) prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+  commit-message:
+    prefix: "build(deps)"
 - package-ecosystem: gomod
   directory: /kubeutils
   schedule:
@@ -28,6 +30,8 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+  commit-message:
+    prefix: "build(deps)"
 - package-ecosystem: gomod
   directory: /modules/kind
   schedule:
@@ -42,6 +46,8 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+  commit-message:
+    prefix: "build(deps)"
 - package-ecosystem: gomod
   directory: /modules/kubeclients
   schedule:
@@ -56,6 +62,8 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+  commit-message:
+    prefix: "build(deps)"
 - package-ecosystem: gomod
   directory: /modules/oci
   schedule:
@@ -70,9 +78,14 @@ updates:
       applies-to: version-updates
       patterns:
       - k8s.io/*
+  commit-message:
+    prefix: "build(deps)"
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
   assignees: [ eqrx ]
   open-pull-requests-limit: 100
+  commit-message:
+    prefix: "build(deps)"
+


### PR DESCRIPTION
Add `build(deps)` prefix to dependabot PRs. This will make filtering of PRs and notifications easier. 