### PR TITLE
Flip task and stream name around in log output to reduce vertical shifts when looking through multiple log lines.

### DIFF
--- a/sh/sh.go
+++ b/sh/sh.go
@@ -55,7 +55,7 @@ func (t taskWriter) Write(p []byte) (n int, err error) {
 	msgLines := bytes.Split(bytes.TrimRight(p, "\n"), []byte{'\n'})
 
 	dateTime := time.Now().UTC().Format("2006-01-02 15:04:05.000")
-	prefix := fmt.Sprintf("%s [%s %s] ", dateTime, t.taskName, t.streamName)
+	prefix := fmt.Sprintf("%s [%s %s] ", dateTime, t.streamName, t.taskName)
 	var prefixedMsg bytes.Buffer
 	for _, line := range msgLines {
 		prefixedMsg.WriteString(prefix)


### PR DESCRIPTION
For me, it's easier to figure out the stream name (ERR or OUT) when it
always sits at the same place in the log line, like this:
```
2025-02-13 08:48:29.933 [OUT govulncheck] Scanning your code and 1222 packages across 148 dependent modules for known vulnerabilities...
2025-02-13 08:48:29.933 [OUT govulncheck]
2025-02-13 08:48:29.933 [OUT govulncheck] Fetching vulnerabilities from the database...
2025-02-13 08:48:29.933 [OUT govulncheck]
2025-02-13 08:48:30.139 [OUT govulncheck] Checking the code against the vulnerabilities...
2025-02-13 08:48:30.139 [OUT govulncheck]
2025-02-13 08:48:30.141 [OUT anothertaskname] blablablabal
2025-02-13 08:48:30.141 [ERR anothertaskname] blablablabal
2025-02-13 08:48:30.139 [ERR govulncheck] oh no an error
```

This is how the output currently looks:
```
2025-02-13 08:48:29.933 [govulncheck OUT] Scanning your code and 1222 packages across 148 dependent modules for known vulnerabilities...
2025-02-13 08:48:29.933 [govulncheck OUT]
2025-02-13 08:48:29.933 [govulncheck OUT] Fetching vulnerabilities from the database...
2025-02-13 08:48:29.933 [govulncheck OUT]
2025-02-13 08:48:30.139 [govulncheck OUT] Checking the code against the vulnerabilities...
2025-02-13 08:48:30.139 [govulncheck OUT]
2025-02-13 08:48:30.141 [anothertaskname OUT] blablablabal
2025-02-13 08:48:30.141 [anothertaskname ERR] blablablabal
2025-02-13 08:48:30.139 [govulncheck ERR] oh no an error
```

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>
